### PR TITLE
init: add parameters for alternate gem sources

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,14 @@
 # Installs infoblox gem
-class infoblox {
+class infoblox (
+  Optional[String] $source = undef,
+  Optional[Array] $install_options = undef,
+) {
 
   package { 'infoblox':
-    ensure   => present,
-    provider => 'puppet_gem',
+    ensure          => present,
+    provider        => 'puppet_gem',
+    source          => $source,
+    install_options => $install_options,
   }
 
 }


### PR DESCRIPTION
I would like to be able to install the infoblox gem on servers in my
environment that only have access to internal rubygems proxies. To do
that in Puppet code, I need to be able to expose these two file resouce
parameters.
